### PR TITLE
Fix default argument error

### DIFF
--- a/cordova-plugin-cloud-settings.d.ts
+++ b/cordova-plugin-cloud-settings.d.ts
@@ -40,7 +40,7 @@ interface CloudSettings {
         settings: object,
         successCallback: (savedSettings: object) => void,
         errorCallback: (error: string) => void,
-        overwrite: boolean = false
+        overwrite?: boolean
     ) => void;
 
     /**


### PR DESCRIPTION
```
A parameter initializer is only allowed in a function or constructor implementation.
    41 |         successCallback: (savedSettings: object) => void,
    42 |         errorCallback: (error: string) => void,
  > 43 |         overwrite: boolean = false
       |         ^
    44 |     ) => void;
```